### PR TITLE
Fix mapping for DomainInterfaceMac & DomainInterfaceModel

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -62,13 +62,13 @@ type DomainInterfaceMAC struct {
 }
 
 type DomainInterfaceModel struct {
-	Type string `xml:type,attr"`
+	Type string `xml:"type,attr"`
 }
 
 type DomainInterface struct {
-	Type  string               `xml:"type,attr"`
-	MAC   string               `xml:"mac"`
-	Model DomainInterfaceModel `xml:"model"`
+	Type  string                `xml:"type,attr"`
+	MAC   *DomainInterfaceMAC   `xml:"mac"`
+	Model *DomainInterfaceModel `xml:"model"`
 }
 
 type DomainChardev struct {

--- a/domain_test.go
+++ b/domain_test.go
@@ -307,6 +307,36 @@ var domainTestData = []struct {
 			`</domain>`,
 		},
 	},
+	{
+		Object: &Domain{
+			Type: "kvm",
+			Name: "test",
+			Devices: &DomainDeviceList{
+				Interfaces: []DomainInterface{
+					DomainInterface{
+						Type: "network",
+						MAC: &DomainInterfaceMAC{
+							Address: "00:11:22:33:44:55",
+						},
+						Model: &DomainInterfaceModel{
+							Type: "virtio",
+						},
+					},
+				},
+			},
+		},
+		Expected: []string{
+			`<domain type="kvm">`,
+			`  <name>test</name>`,
+			`  <devices>`,
+			`    <interface type="network">`,
+			`      <mac address="00:11:22:33:44:55"></mac>`,
+			`      <model type="virtio"></model>`,
+			`    </interface>`,
+			`  </devices>`,
+			`</domain>`,
+		},
+	},
 }
 
 func TestDomain(t *testing.T) {


### PR DESCRIPTION
Corrected syntax error on DomainInterfaceModel. Fields in DomainInterface are changed to correct types. According to https://libvirt.org/formatdomain.html , both MAC and Model can be empty, so pointer type is used.