### PR TITLE
Add omitempty for DomainOSType's Arch and Machine

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -140,8 +140,8 @@ type DomainMaxMemory struct {
 }
 
 type DomainOSType struct {
-	Arch    string `xml:"arch,attr"`
-	Machine string `xml:"machine,attr"`
+	Arch    string `xml:"arch,attr,omitempty"`
+	Machine string `xml:"machine,attr,omitempty"`
 	Type    string `xml:",chardata"`
 }
 


### PR DESCRIPTION
According to https://libvirt.org/formatdomain.html#elementsOSBIOS 's example, it's possible for arch & machine to be empty. 
