### PR TITLE
added possibility to set bandwith parameters to zero

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -216,10 +216,10 @@ type DomainInterfaceVirtualport struct {
 }
 
 type DomainInterfaceBandwidthParams struct {
-	Average int `xml:"average,attr,omitempty"`
-	Peak    int `xml:"peak,attr,omitempty"`
-	Burst   int `xml:"burst,attr,omitempty"`
-	Floor   int `xml:"floor,attr,omitempty"`
+	Average *int `xml:"average,attr,omitempty"`
+	Peak    *int `xml:"peak,attr,omitempty"`
+	Burst   *int `xml:"burst,attr,omitempty"`
+	Floor   *int `xml:"floor,attr,omitempty"`
 }
 
 type DomainInterfaceBandwidth struct {

--- a/domain_test.go
+++ b/domain_test.go
@@ -51,6 +51,9 @@ var serialPort uint = 0
 var tabletBus uint = 0
 var tabletPort uint = 1
 
+var nicAverage int = 1000
+var nicBurst int = 10000
+
 var domainTestData = []struct {
 	Object   Document
 	Expected []string
@@ -922,12 +925,12 @@ var domainTestData = []struct {
 						},
 						Bandwidth: &DomainInterfaceBandwidth{
 							Inbound: &DomainInterfaceBandwidthParams{
-								Average: 1000,
-								Burst:   10000,
+								Average: &nicAverage,
+								Burst:   &nicBurst,
 							},
 							Outbound: &DomainInterfaceBandwidthParams{
-								Average: 1000,
-								Burst:   10000,
+								Average: new(int),
+								Burst:   new(int),
 							},
 						},
 					},
@@ -943,7 +946,7 @@ var domainTestData = []struct {
 			`      <model type="virtio"></model>`,
 			`      <bandwidth>`,
 			`        <inbound average="1000" burst="10000"></inbound>`,
-			`        <outbound average="1000" burst="10000"></outbound>`,
+			`        <outbound average="0" burst="0"></outbound>`,
 			`      </bandwidth>`,
 			`    </interface>`,
 			`  </devices>`,


### PR DESCRIPTION
allows to unset limits - otherwise, if value is not
defined in xml, value is not modified when using
DOMAIN_AFFECT_LIVE

Signed-off-by: Daniel Kucera <kucera@apptocloud.com>