### PR TITLE
Add support for hex values in DomainAddress struct

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -27,6 +27,7 @@ package libvirtxml
 
 import (
 	"encoding/xml"
+	"strconv"
 )
 
 type DomainController struct {
@@ -281,15 +282,15 @@ type DomainAlias struct {
 }
 
 type DomainAddress struct {
-	Type       string `xml:"type,attr"`
-	Controller *uint  `xml:"controller,attr"`
-	Domain     *uint  `xml:"domain,attr"`
-	Bus        *uint  `xml:"bus,attr"`
-	Port       *uint  `xml:"port,attr"`
-	Slot       *uint  `xml:"slot,attr"`
-	Function   *uint  `xml:"function,attr"`
-	Target     *uint  `xml:"target,attr"`
-	Unit       *uint  `xml:"unit,attr"`
+	Type       string   `xml:"type,attr"`
+	Controller *uint    `xml:"controller,attr"`
+	Domain     *HexUint `xml:"domain,attr"`
+	Bus        *HexUint `xml:"bus,attr"`
+	Port       *uint    `xml:"port,attr"`
+	Slot       *HexUint `xml:"slot,attr"`
+	Function   *HexUint `xml:"function,attr"`
+	Target     *uint    `xml:"target,attr"`
+	Unit       *uint    `xml:"unit,attr"`
 }
 
 type DomainConsole struct {
@@ -791,4 +792,12 @@ func (d *DomainRNG) Marshal() (string, error) {
 		return "", err
 	}
 	return string(doc), nil
+}
+
+type HexUint uint
+
+func (h *HexUint) UnmarshalXMLAttr(attr xml.Attr) error {
+	val, err := strconv.ParseUint(attr.Value, 0, 32)
+	*h = HexUint(val)
+	return err
 }

--- a/domain_test.go
+++ b/domain_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 type Address struct {
-	Domain   uint
-	Bus      uint
-	Slot     uint
-	Function uint
+	Domain   HexUint
+	Bus      HexUint
+	Slot     HexUint
+	Function HexUint
 }
 
 var uhciIndex uint = 0
@@ -48,7 +48,7 @@ var balloonAddr = Address{0, 0, 7, 0}
 var duplexAddr = Address{0, 0, 8, 0}
 
 var serialPort uint = 0
-var tabletBus uint = 0
+var tabletBus HexUint = 0
 var tabletPort uint = 1
 
 var nicAverage int = 1000


### PR DESCRIPTION
Hello everyone!
This PR fix problem with parsing hex values in Device Address element. By default encoding.xml calls **strconv.ParseUint(string(src), 10, dst.Type().Bits())** for **uint** type what results in error: **strconv.ParseUint: parsing "0x0000": invalid syntax**
Custom type HexUint handle such values properly.