### PR TITLE
Add Numa support to DomainCPU

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -532,6 +532,18 @@ type DomainCPU struct {
 	Vendor   string             `xml:"vendor,omitempty"`
 	Topology *DomainCPUTopology `xml:"topology"`
 	Features []DomainCPUFeature `xml:"feature"`
+	Numa     *DomainNuma        `xml:"numa,omitempty"`
+}
+
+type DomainNuma struct {
+	Cell []DomainCell `xml:"cell"`
+}
+
+type DomainCell struct {
+	ID     string `xml:"id,attr"`
+	CPUs   string `xml:"cpus,attr"`
+	Memory string `xml:"memory,attr"`
+	Unit   string `xml:"unit,attr"`
 }
 
 type DomainClock struct {

--- a/domain_test.go
+++ b/domain_test.go
@@ -659,6 +659,11 @@ var domainTestData = []struct {
 				Features: []DomainCPUFeature{
 					DomainCPUFeature{Policy: "disable", Name: "lahf_lm"},
 				},
+				Numa: &DomainNuma{
+					[]DomainCell{
+						{ID: "0", CPUs: "0-3", Memory: "512000", Unit: "KiB"},
+					},
+				},
 			},
 			Devices: &DomainDeviceList{
 				Emulator: "/bin/qemu-kvm",
@@ -672,6 +677,9 @@ var domainTestData = []struct {
 			`    <vendor>Intel</vendor>`,
 			`    <topology sockets="1" cores="2" threads="1"></topology>`,
 			`    <feature policy="disable" name="lahf_lm"></feature>`,
+			`    <numa>`,
+			`      <cell id="0" cpus="0-3" memory="512000" unit="KiB"></cell>`,
+			`    </numa>`,
 			`  </cpu>`,
 			`  <devices>`,
 			`    <emulator>/bin/qemu-kvm</emulator>`,


### PR DESCRIPTION
This patch add Numa field in DomainCPU so that we can support Numa in QEMU/KVM.

Signed-off-by: Crazykev <crazykev@zju.edu.cn>