### PR TITLE
Add Timer support in DomainClock

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -534,9 +534,26 @@ type DomainCPU struct {
 }
 
 type DomainClock struct {
-	Offset     string `xml:"offset,attr,omitempty"`
-	Basis      string `xml:"basis,attr,omitempty"`
-	Adjustment int    `xml:"adjustment,attr,omitempty"`
+	Offset     string        `xml:"offset,attr,omitempty"`
+	Basis      string        `xml:"basis,attr,omitempty"`
+	Adjustment int           `xml:"adjustment,attr,omitempty"`
+	Timer      []DomainTimer `xml:"timer,omitempty"`
+}
+
+type DomainTimer struct {
+	Name       string         `xml:"name,attr"`
+	Track      string         `xml:"track,attr,omitempty"`
+	TickPolicy string         `xml:"tickpolicy,attr,omitempty"`
+	CatchUp    *DomainCatchUp `xml:"catchup,omitempty"`
+	Frequency  uint32         `xml:"frequency,attr,omitempty"`
+	Mode       string         `xml:"mode,attr,omitempty"`
+	Present    string         `xml:"present,attr,omitempty"`
+}
+
+type DomainCatchUp struct {
+	Threshold uint `xml:"threshold,attr,omitempty"`
+	Slew      uint `xml:"slew,attr,omitempty"`
+	Limit     uint `xml:"limit,attr,omitempty"`
 }
 
 type DomainFeature struct {

--- a/domain_test.go
+++ b/domain_test.go
@@ -498,6 +498,20 @@ var domainTestData = []struct {
 				Offset:     "variable",
 				Basis:      "utc",
 				Adjustment: 28794,
+				Timer: []DomainTimer{
+					DomainTimer{
+						Name:       "rtc",
+						Track:      "boot",
+						TickPolicy: "catchup",
+						CatchUp: &DomainCatchUp{
+							Threshold: 123,
+							Slew:      120,
+							Limit:     10000,
+						},
+						Frequency: 120,
+						Mode:      "auto",
+					},
+				},
 			},
 		},
 		Expected: []string{
@@ -532,7 +546,11 @@ var domainTestData = []struct {
 			`    <initarg>--unit</initarg>`,
 			`    <initarg>emergency.service</initarg>`,
 			`  </os>`,
-			`  <clock offset="variable" basis="utc" adjustment="28794"></clock>`,
+			`  <clock offset="variable" basis="utc" adjustment="28794">`,
+			`    <timer name="rtc" track="boot" tickpolicy="catchup" frequency="120" mode="auto">`,
+			`      <catchup threshold="123" slew="120" limit="10000"></catchup>`,
+			`    </timer>`,
+			`  </clock>`,
 			`</domain>`,
 		},
 	},


### PR DESCRIPTION
This patch add Timer field in DomainClock.

Signed-off-by: Crazykev <crazykev@zju.edu.cn>