### PR TITLE
fixed a typo in code; Update domain.go

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -568,7 +568,7 @@ type DomainInterfaceGuest struct {
 
 type DomainInterfaceFilterRef struct {
 	Filter      string                       `xml:"filter,attr"`
-	Pararmeters []DomainInterfaceFilterParam `xml:"parameter"`
+	Parameters []DomainInterfaceFilterParam `xml:"parameter"`
 }
 
 type DomainInterfaceFilterParam struct {


### PR DESCRIPTION
fixed a typo in ```DomainInterfaceFilterRef``` struct. Pararmeters should be Parameters